### PR TITLE
Downgrade faraday version

### DIFF
--- a/omniauth-familysearch.gemspec
+++ b/omniauth-familysearch.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('faraday', '~> 0.8.9')
   gem.add_runtime_dependency('omniauth-oauth2', '~> 1.0')
 
-
   gem.add_development_dependency 'rspec', '~> 2.7'
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'simplecov'


### PR DESCRIPTION
This is hack is necessary to use along with `familysearch` gem, which
requires `faraday_middleware`.
