### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Here's an example Auth Hash available in `request.env['omniauth.auth']`:
 
 ## FamilySearch OAuth 2 Docs
 
-https://familysearch.org/developers/docs/guides/oauth2
+https://familysearch.org/developers/docs/guides/authentication
 
 ## Contributing
 


### PR DESCRIPTION
The previous reference to the oath2 document on FamilySearch is outdated. I updated it with the URL to the current OAuth2 FamilySearch Authentication document.
